### PR TITLE
New groups/tabs for child project

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,12 @@ highlighter: pygments
 baseurl: http://myria.cs.washington.edu
 
 include: ['myria-docs']
+
+defaults:
+  -
+    scope:
+      path: "docs/myriax/"
+      type: "pages"
+    values:
+      group: "myriax"
+


### PR DESCRIPTION
Dominik, let's brainstorm how we want the child repos to appear on the website.  I propose we set a default group for those pages (see commit).  The pages then need specify only a title, and maybe a weight.  We then do some trick like in the _includes folder's files that adds all the pages in that group to a subtab.

Can you play around with the tabs?  I tried but messed it up.
